### PR TITLE
Fixes typo in PEDRAC

### DIFF
--- a/Public/PEDRAC.ps1
+++ b/Public/PEDRAC.ps1
@@ -286,7 +286,7 @@ function Set-PEADRoleGroup
     Param
     (
         # iDRAC Session Object
-        [Parameter(Mandatory=$true
+        [Parameter(Mandatory=$true,
                    Position=0,
                    ParameterSetName='General')]
         [Parameter(Mandatory=$true,


### PR DESCRIPTION
Typo in the Mandatory param attribute declaration. Module import fails.